### PR TITLE
Add settings menu to forecast

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,10 @@
 
 .app {
-  max-width: 1080px;
-  margin: 20px auto;
+  /* max-width: 1080px; */
+  /* margin: 20px auto; */
 
 }
 
 body {
-  background-color: #f5f4f4;
+  /* background-color: #f5f4f4; */
 }

--- a/src/components/AddSettingModal.js/AddSettingModal.scss
+++ b/src/components/AddSettingModal.js/AddSettingModal.scss
@@ -7,17 +7,19 @@
     padding: 1rem;
     padding-bottom: 0.25rem;
     margin-top: -5rem;
-    z-index: 1;
+    z-index: 3;
 
     @include tablet {
         padding: 0 2rem 0.25rem 2rem;
         margin-top: -7rem;
         height: 87vh;
+        z-index: 3;
     }
 
     @include desktop {
         padding: 0 10vw 0.25rem 10vw;
         margin-top: -7rem;
+        z-index: 3;
     }
 
     &__container {
@@ -76,7 +78,7 @@
     &-form {
         width: 100%;
     }
-    
+
 }
 
 .no-scroll {
@@ -94,7 +96,7 @@
         left: 0;
         display: flex;
         justify-content: center;
-        
+
         z-index: 2;
 
         @include tablet {
@@ -104,22 +106,27 @@
 
     &__content {
         height: 100%;
-        position: relative;
+        position: fixed;
         background-color: $White;
         padding: 1rem 1rem 0 1rem;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
+        z-index: 3;
 
         @include tablet {
+            position: fixed;
             width: 85vw;
             height: 30vh;
-            top: 21%
+            top: 21%;
+            z-index: 3;
         }
 
         @include desktop {
+            position: fixed;
             width: 55vw;
             height: 320px;
+            z-index: 3;
         }
     }
 
@@ -135,7 +142,7 @@
 
     &__text-container {
         width: 100%;
-        
+
         @include tablet {
             padding: 0 0 0 2rem;
             width: 80%;

--- a/src/components/AlertBoard/AlertBoard.js
+++ b/src/components/AlertBoard/AlertBoard.js
@@ -50,7 +50,7 @@ const AlertBoard = () => {
     
     return (
         <div className="alerts">
-            <h1 className="alerts__title">Weather Alerts</h1>
+            <h2 className="alerts__title">Weather Alerts</h2>
             <ul className="alerts__cards-container">
                 {alerts.map(alert => (
                     <div className="alerts__card" key={alert.id}>

--- a/src/components/AlertBoard/AlertBoard.scss
+++ b/src/components/AlertBoard/AlertBoard.scss
@@ -16,7 +16,7 @@
 
     &__title {
         padding: 2rem 0;
-        @extend .text-style-page-header-desk
+        // @extend .text-style-page-header-desk
     }
 
     &__sub-title {

--- a/src/components/Forecast/Forecast.js
+++ b/src/components/Forecast/Forecast.js
@@ -8,7 +8,8 @@ import axios from "axios";
 import TodayWeather from "../TodayWeather/TodayWeather";
 import Carousel from "../Carousel/Carousel";
 import AlertBoard from "../AlertBoard/AlertBoard";
-import SettingsList from "../SettingsList/SettingsList"
+import Settings from "../../pages/Settings/Settings";
+// import SettingsList from "../SettingsList/SettingsList"
 
 const Forecast = ({ userLocation }) => {
     const [currentWeather, setCurrentWeather] = useState(null);
@@ -53,11 +54,11 @@ const Forecast = ({ userLocation }) => {
                 <h2 className="forecast__sub-title">Daily</h2>
                 <Carousel weatherData={forecastWeather} />
             </div> */}
-            <div className="alert__container">
+            {/* <div className="alert__container">
                 <AlertBoard />
-            </div>
+            </div> */}
             <div className="settings_container">
-                {/* <SettingsList /> */}
+                <Settings />
             </div>
         </section>
     );

--- a/src/components/Forecast/Forecast.scss
+++ b/src/components/Forecast/Forecast.scss
@@ -22,3 +22,12 @@
     }
 
 }
+
+.forecast__container {
+    padding-right: 3rem;
+}
+
+.settings__container {
+    position: relative;
+    padding-right: 1rem;
+}

--- a/src/components/NavBar/NavBar.scss
+++ b/src/components/NavBar/NavBar.scss
@@ -3,10 +3,11 @@
 @import '../../styles/partials/mixins';
 
 .navbar {
+    // padding-right: 2rem
 
     &__list {
         list-style: none;
-        padding: 0;
+        padding: 0 2rem 0 0;
         margin: 0;
         display: flex;
         justify-content: flex-end;

--- a/src/components/SettingsItem/SettingsItem.scss
+++ b/src/components/SettingsItem/SettingsItem.scss
@@ -5,7 +5,7 @@
 .settings-item {
     display: flex;
     flex-direction: column;
-    padding: 1rem;
+    padding: 1rem 1rem 1rem 0;
     width: 100%;
 
     &:not(:last-child) {
@@ -18,12 +18,12 @@
 
     @include tablet {
         flex-direction: row;
-        padding: 1rem 2rem;
+        padding: 1rem 2rem 1rem 0;
     }
 
     @include desktop {
         flex-direction: row;
-        padding: 1rem 2rem;
+        padding: 1rem 2rem 1rem 0;
     }
 
     &__container {
@@ -138,13 +138,11 @@
 
         @include tablet {
             width: 9.09vw;
-            justify-content: end;
             gap: 1rem;
         }
 
         @include desktop {
             width: 9.09vw;
-            justify-content: end;
             gap: 1rem;
         }
 

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -161,13 +161,12 @@ const Settings = () => {
     return (
         <>
             <main>
-                <Header />
                 <section className="settings">
                     <div className="settings__container">
                         <section className="settings__header">
                             <h2 className="settings__title">Settings</h2>
                             <div className="settings__right">
-                                <div className='settings__location-container'>
+                                {/* <div className='settings__location-container'>
                                     <h3 className='dashboard__title'>
                                         CURRENT LOCATION: {userCity}
                                     </h3>
@@ -189,7 +188,7 @@ const Settings = () => {
                                             alt="update location icon"
                                             onClick={openModal} />
                                     </div>
-                                </div>
+                                </div> */}
                                 <div className="settings-item__actions">
                                     <AddSettingModal
                                         isSettingsOpen={isSettingsModalOpen}

--- a/src/pages/Settings/Settings.scss
+++ b/src/pages/Settings/Settings.scss
@@ -3,10 +3,9 @@
 @import '../../styles/partials/mixins';
 
 .settings {
-    padding: 24px 240px 24px 240px;
 
     &__title{
-        padding-bottom: 8px;
+        padding: 2rem 0 8px 0;
     }
     &__location-container{
         display: flex;
@@ -21,6 +20,7 @@
         font-weight: 600;
         font-size: 20px;
     }
+
     // padding: 1rem;
     // padding-bottom: 0.25rem;
     // margin-top: -5rem;

--- a/src/pages/Weather/Weather.scss
+++ b/src/pages/Weather/Weather.scss
@@ -10,7 +10,7 @@
         justify-content: center;
         align-items: center;
         // height: 300px;
-        background: linear-gradient(45deg, hsla(0, 0%, 89%), hsla(0, 0%, 48%));
+        // background: linear-gradient(45deg, hsla(0, 0%, 89%), hsla(0, 0%, 48%));
         height: 100vh;
     }
 

--- a/src/styles/partials/_global.scss
+++ b/src/styles/partials/_global.scss
@@ -9,7 +9,8 @@
 
 body {
     width: 100vw;
-    background-color: $Light-Grey;
+    // background-color: $Light-Grey;
+    background: linear-gradient(45deg, hsla(0, 0%, 89%), hsla(0, 0%, 48%));
 
     //     @include font-styling(400, $Instock-Black);
 
@@ -96,41 +97,41 @@ body {
         }
     }
 
-    p1 {
-        @include format-text(1.625rem, 0.9375rem, 400);
+    // p1 {
+    //     @include format-text(1.625rem, 0.9375rem, 400);
 
-        @include tablet {
-            @include format-text(1.75rem, 1rem, 400);
-        }
+    //     @include tablet {
+    //         @include format-text(1.75rem, 1rem, 400);
+    //     }
 
-        @include desktop {
-            @include format-text(1.75rem, 1rem, 400);
-        }
-    }
+    //     @include desktop {
+    //         @include format-text(1.75rem, 1rem, 400);
+    //     }
+    // }
 
-    p2 {
-        @include format-text(1.25rem, 0.8125rem, 400);
+    // p2 {
+    //     @include format-text(1.25rem, 0.8125rem, 400);
 
-        @include tablet {
-            @include format-text(1.375rem, 0.875rem, 400);
-        }
+    //     @include tablet {
+    //         @include format-text(1.375rem, 0.875rem, 400);
+    //     }
 
-        @include desktop {
-            @include format-text(1.375rem, 0.875rem, 400);
-        }
-    }
+    //     @include desktop {
+    //         @include format-text(1.375rem, 0.875rem, 400);
+    //     }
+    // }
 
-    p3 {
-        @include format-text(1rem, 0.6875rem, 400);
+    // p3 {
+    //     @include format-text(1rem, 0.6875rem, 400);
 
-        @include tablet {
-            @include format-text(1.125rem, 0.75rem, 400);
-        }
+    //     @include tablet {
+    //         @include format-text(1.125rem, 0.75rem, 400);
+    //     }
 
-        @include desktop {
-            @include format-text(1.125rem, 0.75rem, 400);
-        }
-    }
+    //     @include desktop {
+    //         @include format-text(1.125rem, 0.75rem, 400);
+    //     }
+    // }
 
 
     // Labes & Button Styles


### PR DESCRIPTION
## Description
In this update, I added AlertBoard as a child component of Forecast, the side menu that show's the weather forecast. Adjusted styling on all related components to ensure they are within the right boundary.

## Changes Made To:
        modified:   src/components/AddSettingModal.js/AddSettingModal.scss
        modified:   src/components/AlertBoard/AlertBoard.js
        modified:   src/components/AlertBoard/AlertBoard.scss
        modified:   src/components/Forecast/Forecast.js
        modified:   src/components/Forecast/Forecast.scss
        modified:   src/components/NavBar/NavBar.scss
        modified:   src/components/SettingsItem/SettingsItem.scss
        modified:   src/pages/Settings/Settings.js
        modified:   src/pages/Settings/Settings.scss
        modified:   src/pages/Weather/Weather.scss
        modified:   src/styles/partials/_global.scss

## Dependencies
- WeatherCap API server
- MySQL 'alerts' table

## Testing
- successfully loaded settings from API.

## Future Work
- need to move modals to Hero component as they are currently limited by their parent component's z-index(Forecast.js) being lower than than the Hero component